### PR TITLE
Pass image as argument to object

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,16 +5,18 @@ from pygame.locals import *
 from src.game_window import GameWindow
 from src.rocket import Rocket
 from src.landing_site import LandingSite
+from src.vec2d import Vec2d
 from src.colors import colors_dict
 from src.common_constants import CommonConstants
 
 pygame.init()
 game_window = GameWindow("Landing Game")
+rocket_pos = Vec2d(CommonConstants.WINDOW_WIDTH / 2, CommonConstants.WINDOW_HEIGHT / 2)
+rocket_mass = 1e5
+img = pygame.Surface((40, 30))
+img.fill(colors_dict["red"])
 
-rocket = Rocket(
-    600, 100, 50, 50, colors_dict["red"], 0, 0
-)  # TODO find out, why the rocket is not displayed correctly
-ground = LandingSite(200, 200, 100, 20)
+ego = Rocket(img, rocket_pos, rocket_mass)
 
 while True:
     for event in pygame.event.get():
@@ -22,7 +24,7 @@ while True:
             pygame.quit()
             sys.exit()
     game_window.erase_screen()
-    ground.draw(game_window.display)
-    rocket.draw(game_window.display)
+    ego.update(CommonConstants.TIME_STEP)
+    game_window.display.blit(ego.image, ego.rect)
     pygame.display.update()
     game_window.clock.tick(game_window.fps)

--- a/main.py
+++ b/main.py
@@ -4,19 +4,36 @@ from pygame.locals import *
 
 from src.game_window import GameWindow
 from src.rocket import Rocket
-from src.landing_site import LandingSite
+from src.landing_game_object import LandingGameObject
 from src.vec2d import Vec2d
 from src.colors import colors_dict
 from src.common_constants import CommonConstants
+
+
+def create_pg_surface_from_color_and_size(color, size):
+    surf = pygame.Surface(size)
+    surf.fill(color)
+    return surf
+
 
 pygame.init()
 game_window = GameWindow("Landing Game")
 rocket_pos = Vec2d(CommonConstants.WINDOW_WIDTH / 2, CommonConstants.WINDOW_HEIGHT / 2)
 rocket_mass = 1e5
-img = pygame.Surface((40, 30))
-img.fill(colors_dict["red"])
+ground_position = Vec2d(0, 500)
+img_ego = create_pg_surface_from_color_and_size(colors_dict["red"], (40, 30))
+img_ground = create_pg_surface_from_color_and_size(
+    colors_dict["green"], (CommonConstants.WINDOW_WIDTH, 10)
+)
 
-ego = Rocket(img, rocket_pos, rocket_mass)
+
+ego = Rocket(img_ego, rocket_pos, rocket_mass)
+ground = LandingGameObject(img_ground, ground_position)
+
+obj_list = pygame.sprite.Group()
+
+obj_list.add(ego)
+obj_list.add(ground)
 
 while True:
     for event in pygame.event.get():
@@ -24,7 +41,8 @@ while True:
             pygame.quit()
             sys.exit()
     game_window.erase_screen()
-    ego.update(CommonConstants.TIME_STEP)
-    game_window.display.blit(ego.image, ego.rect)
+    for i, obj in enumerate(obj_list):
+        obj.update(CommonConstants.TIME_STEP)
+        game_window.display.blit(obj.image, obj.rect)
     pygame.display.update()
     game_window.clock.tick(game_window.fps)

--- a/src/landing_game_object.py
+++ b/src/landing_game_object.py
@@ -8,6 +8,7 @@ class LandingGameObject(pygame.sprite.Sprite):
 
     def __init__(
         self,
+        image: pygame.surface,
         dimensions: Dimensions2D = Dimensions2D(),
         pos: Vec2d = Vec2d(),
     ) -> None:
@@ -15,6 +16,7 @@ class LandingGameObject(pygame.sprite.Sprite):
         self.rect: pygame.Rect = pygame.Rect(0, 0, 0, 0)
         self.pos = pos
         self.dimensions = dimensions
+        self.image = image
         self.align_rect_to_position()
 
     def align_rect_to_position(self) -> None:

--- a/src/landing_game_object.py
+++ b/src/landing_game_object.py
@@ -10,6 +10,13 @@ class LandingGameObject(pygame.sprite.Sprite):
         image: pygame.surface,
         pos: Vec2d = Vec2d(),
     ) -> None:
+        super().__init__()
         self.rect: pygame.Rect = pygame.Surface.get_rect(image)
         self.pos = pos
+        self.rect.center = self.pos
         self.image = image
+
+    def update(self, time_step: float) -> None:
+        # takes timestep argument like physical object,
+        # to be able to treat them in the same way
+        self.rect.center = self.pos

--- a/src/landing_game_object.py
+++ b/src/landing_game_object.py
@@ -1,5 +1,4 @@
 import pygame
-from src.dimensions2d import Dimensions2D
 from src.vec2d import Vec2d
 
 
@@ -9,18 +8,8 @@ class LandingGameObject(pygame.sprite.Sprite):
     def __init__(
         self,
         image: pygame.surface,
-        dimensions: Dimensions2D = Dimensions2D(),
         pos: Vec2d = Vec2d(),
     ) -> None:
-        pygame.sprite.Sprite.__init__(self)
-        self.rect: pygame.Rect = pygame.Rect(0, 0, 0, 0)
+        self.rect: pygame.Rect = pygame.Surface.get_rect(image)
         self.pos = pos
-        self.dimensions = dimensions
         self.image = image
-        self.align_rect_to_position()
-
-    def align_rect_to_position(self) -> None:
-        """Assign current position and dimensions to object's rect"""
-        self.rect.width = self.dimensions.width
-        self.rect.height = self.dimensions.height
-        self.rect.center = (self.pos.x, self.pos.y)

--- a/src/landing_site.py
+++ b/src/landing_site.py
@@ -7,7 +7,8 @@ class LandingSite(pygame.sprite.Sprite):
         super().__init__()
         self.image = pygame.Surface([width, height])
         self.image.fill(colors_dict["green"])
-        self.rect = self.image.get_rect()
+        if self.image is not None:
+            self.rect = self.image.get_rect()
         self.rect.x = x
         self.rect.y = y
 

--- a/src/linear_physical_object.py
+++ b/src/linear_physical_object.py
@@ -1,3 +1,4 @@
+import pygame
 from src.vec2d import Vec2d
 from src.linear_kinematic import LinearKinematic
 from src.landing_game_object import LandingGameObject
@@ -7,6 +8,7 @@ from src.dimensions2d import Dimensions2D
 class LinearPhysicalObject(LandingGameObject, LinearKinematic):
     def __init__(
         self,
+        image: pygame.surface,
         dimensions: Dimensions2D,
         pos: Vec2d,
         mass: float,
@@ -14,7 +16,7 @@ class LinearPhysicalObject(LandingGameObject, LinearKinematic):
         acceleration: Vec2d = Vec2d(),
     ):
 
-        LandingGameObject.__init__(self, dimensions, pos)
+        LandingGameObject.__init__(self, image, dimensions, pos)
         self.kinematic = LinearKinematic(mass, velocity, acceleration)
 
     def step(self, time_step_width: float) -> None:

--- a/src/linear_physical_object.py
+++ b/src/linear_physical_object.py
@@ -1,4 +1,3 @@
-from typing import Any
 import pygame
 from src.vec2d import Vec2d
 from src.linear_kinematic import LinearKinematic

--- a/src/linear_physical_object.py
+++ b/src/linear_physical_object.py
@@ -1,22 +1,21 @@
+from typing import Any
 import pygame
 from src.vec2d import Vec2d
 from src.linear_kinematic import LinearKinematic
 from src.landing_game_object import LandingGameObject
-from src.dimensions2d import Dimensions2D
 
 
 class LinearPhysicalObject(LandingGameObject, LinearKinematic):
     def __init__(
         self,
         image: pygame.surface,
-        dimensions: Dimensions2D,
         pos: Vec2d,
         mass: float,
         velocity: Vec2d = Vec2d(),
         acceleration: Vec2d = Vec2d(),
     ):
 
-        LandingGameObject.__init__(self, image, dimensions, pos)
+        LandingGameObject.__init__(self, image, pos)
         self.kinematic = LinearKinematic(mass, velocity, acceleration)
 
     def step(self, time_step_width: float) -> None:
@@ -36,3 +35,7 @@ class LinearPhysicalObject(LandingGameObject, LinearKinematic):
         )
         self.pos = new_pos
         self.kinematic.set_velocity(new_velocity)
+
+    def update(self, time_step):
+        self.step(time_step)
+        self.rect.center = self.pos

--- a/src/rocket.py
+++ b/src/rocket.py
@@ -1,4 +1,4 @@
-from src.dimensions2d import Dimensions2D
+import pygame
 from src.vec2d import Vec2d
 from src.linear_physical_object import LinearPhysicalObject
 
@@ -6,10 +6,10 @@ from src.linear_physical_object import LinearPhysicalObject
 class Rocket(LinearPhysicalObject):
     def __init__(
         self,
-        dimensions: Dimensions2D,
+        image: pygame.surface,
         pos: Vec2d,
         mass: float,
         velocity: Vec2d = Vec2d(),
         acceleration: Vec2d = Vec2d(),
     ):
-        LinearPhysicalObject.__init__(dimensions, pos, mass, velocity, acceleration)
+        LinearPhysicalObject.__init__(self, image, pos, mass, velocity, acceleration)

--- a/test/test_landing_game_object.py
+++ b/test/test_landing_game_object.py
@@ -1,29 +1,25 @@
+import pygame
+import pytest
+
 from src.landing_game_object import LandingGameObject
-from src.dimensions2d import Dimensions2D
 from src.vec2d import Vec2d
+from src.colors import colors_dict
+
+
+@pytest.fixture
+def example_image():
+    img = pygame.Surface((40, 30))
+    img.fill(colors_dict["red"])
+    return img
 
 
 class TestLandingGameObject:
-    def test_initialization(self):
-        dimensions = Dimensions2D(200, 200)
-        position = Vec2d(100, 100)
-        obj = LandingGameObject(image=None, dimensions=dimensions, pos=position)
 
-        assert obj.dimensions == dimensions
+    def test_initialization(self, example_image):
+        position = Vec2d(100, 100)
+        obj = LandingGameObject(image=example_image, pos=position)
+
         assert obj.pos == position
-        assert obj.rect.width == dimensions.width
-        assert obj.rect.height == dimensions.height
+        assert obj.rect.width == example_image.get_width()
+        assert obj.rect.height == example_image.get_height()
         assert obj.rect.center == (position.x, position.y)
-
-    def test_align_rect_to_position(self):
-        dimensions = Dimensions2D(200, 200)
-        position = Vec2d(100, 100)
-        obj = LandingGameObject(image=None, dimensions=dimensions, pos=position)
-
-        new_position = Vec2d(300, 300)
-        obj.pos = new_position
-        obj.align_rect_to_position()
-
-        assert obj.rect.center == new_position
-        assert obj.rect.width == dimensions.width
-        assert obj.rect.height == dimensions.height

--- a/test/test_landing_game_object.py
+++ b/test/test_landing_game_object.py
@@ -7,7 +7,7 @@ class TestLandingGameObject:
     def test_initialization(self):
         dimensions = Dimensions2D(200, 200)
         position = Vec2d(100, 100)
-        obj = LandingGameObject(dimensions, position)
+        obj = LandingGameObject(image=None, dimensions=dimensions, pos=position)
 
         assert obj.dimensions == dimensions
         assert obj.pos == position
@@ -18,7 +18,7 @@ class TestLandingGameObject:
     def test_align_rect_to_position(self):
         dimensions = Dimensions2D(200, 200)
         position = Vec2d(100, 100)
-        obj = LandingGameObject(dimensions, position)
+        obj = LandingGameObject(image=None, dimensions=dimensions, pos=position)
 
         new_position = Vec2d(300, 300)
         obj.pos = new_position

--- a/test/test_linear_physical_object.py
+++ b/test/test_linear_physical_object.py
@@ -14,11 +14,27 @@ class TestLinearPhysicalObject:
         self.mass = 1e5
 
     def test_init(self):
-        LinearPhysicalObject(
-            self.dimensions, self.position, self.mass, self.velocity, self.acceleration
+        obj = LinearPhysicalObject(
+            image=None,
+            dimensions=self.dimensions,
+            pos=self.position,
+            mass=self.mass,
+            velocity=self.velocity,
+            acceleration=self.acceleration,
         )
-        LinearPhysicalObject(self.dimensions, self.position, self.mass, self.velocity)
-        LinearPhysicalObject(self.dimensions, self.position, self.mass)
+        obj = LinearPhysicalObject(
+            image=None,
+            dimensions=self.dimensions,
+            pos=self.position,
+            mass=self.mass,
+            velocity=self.velocity,
+        )
+        obj = LinearPhysicalObject(
+            image=None,
+            dimensions=self.dimensions,
+            pos=self.position,
+            mass=self.mass,
+        )
 
     def test_step(self):
         time_step = 0.1
@@ -28,7 +44,12 @@ class TestLinearPhysicalObject:
         expected_new_position = self.position + time_step * self.velocity
 
         obj = LinearPhysicalObject(
-            self.dimensions, self.position, self.mass, self.velocity, self.acceleration
+            image=None,
+            dimensions=self.dimensions,
+            pos=self.position,
+            mass=self.mass,
+            velocity=self.velocity,
+            acceleration=self.acceleration,
         )
         obj.step(time_step)
         assert obj.pos == expected_new_position

--- a/test/test_linear_physical_object.py
+++ b/test/test_linear_physical_object.py
@@ -1,7 +1,17 @@
+import pygame
 import pytest
+
+from src.colors import colors_dict
 from src.linear_physical_object import LinearPhysicalObject
 from src.dimensions2d import Dimensions2D
 from src.vec2d import Vec2d
+
+
+@pytest.fixture
+def example_image():
+    img = pygame.Surface((40, 30))
+    img.fill(colors_dict["red"])
+    return img
 
 
 class TestLinearPhysicalObject:
@@ -13,30 +23,27 @@ class TestLinearPhysicalObject:
         self.acceleration = Vec2d(-10, 2)
         self.mass = 1e5
 
-    def test_init(self):
+    def test_init(self, example_image):
         obj = LinearPhysicalObject(
-            image=None,
-            dimensions=self.dimensions,
+            image=example_image,
             pos=self.position,
             mass=self.mass,
             velocity=self.velocity,
             acceleration=self.acceleration,
         )
         obj = LinearPhysicalObject(
-            image=None,
-            dimensions=self.dimensions,
+            image=example_image,
             pos=self.position,
             mass=self.mass,
             velocity=self.velocity,
         )
         obj = LinearPhysicalObject(
-            image=None,
-            dimensions=self.dimensions,
+            image=example_image,
             pos=self.position,
             mass=self.mass,
         )
 
-    def test_step(self):
+    def test_step(self, example_image):
         time_step = 0.1
         non_admissible_time_step = -0.1
 
@@ -44,8 +51,7 @@ class TestLinearPhysicalObject:
         expected_new_position = self.position + time_step * self.velocity
 
         obj = LinearPhysicalObject(
-            image=None,
-            dimensions=self.dimensions,
+            image=example_image,
             pos=self.position,
             mass=self.mass,
             velocity=self.velocity,

--- a/test/test_rocket.py
+++ b/test/test_rocket.py
@@ -1,0 +1,64 @@
+import pygame
+import pytest
+
+from src.colors import colors_dict
+from src.rocket import Rocket
+from src.dimensions2d import Dimensions2D
+from src.vec2d import Vec2d
+
+
+@pytest.fixture
+def example_image():
+    img = pygame.Surface((40, 30))
+    img.fill(colors_dict["red"])
+    return img
+
+
+class TestRocket:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.dimensions = Dimensions2D(4, 8)
+        self.position = Vec2d(10, 50)
+        self.velocity = Vec2d(5, 50)
+        self.acceleration = Vec2d(-10, 2)
+        self.mass = 1e5
+
+    def test_init(self, example_image):
+        Rocket(
+            image=example_image,
+            pos=self.position,
+            mass=self.mass,
+            velocity=self.velocity,
+            acceleration=self.acceleration,
+        )
+        Rocket(
+            image=example_image,
+            pos=self.position,
+            mass=self.mass,
+            velocity=self.velocity,
+        )
+        Rocket(
+            image=example_image,
+            pos=self.position,
+            mass=self.mass,
+        )
+
+    def test_step(self, example_image):
+        time_step = 0.1
+        non_admissible_time_step = -0.1
+
+        expected_new_velocity = self.velocity + time_step * self.acceleration
+        expected_new_position = self.position + time_step * self.velocity
+
+        obj = Rocket(
+            image=example_image,
+            pos=self.position,
+            mass=self.mass,
+            velocity=self.velocity,
+            acceleration=self.acceleration,
+        )
+        obj.step(time_step)
+        assert obj.pos == expected_new_position
+        assert obj.kinematic.velocity == expected_new_velocity
+        with pytest.raises(ValueError):
+            obj.step(non_admissible_time_step)


### PR DESCRIPTION
## Description
Object dynamics should not depend on their respective visual representation. Hence, when creating the object, pass the visualization (called `image`, being a `pygame.Surface` object) to the object constructor (see "Dependency Injection Design Pattern"). 

## Changes
* make `image` constructor arguments of the object classes
* read dimensions via `image.get_rect()` to avoid redundant size information
* tests on `Rocket` to verify that it keeps parent functionality (could be harmed by bad `__init__` calls)

## How to Test
* run given unit tests
* run `main.py`