### PR TITLE
27 add attribute name to landinggameobject class

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from src.common_constants import CommonConstants, GameFonts, Opacity
 from src.overlay import Overlay
 from src.game_timing import GameTiming
 from src.landing_game_action_on_key import PygameKeyState, LandingGameActionOnKey
+from src.object_library import ObjectLibrary
 
 
 def create_pg_surface_from_color_and_size(color, size):
@@ -22,6 +23,7 @@ def create_pg_surface_from_color_and_size(color, size):
 
 def create_overlays(ground, ego, game_timing):
     debug_overlay = Overlay(
+        "debug_overlay",
         create_pg_surface_from_color_and_size(
             colors_dict["black"], (CommonConstants.WINDOW_WIDTH / 3, 400)
         ),
@@ -41,6 +43,7 @@ def create_overlays(ground, ego, game_timing):
     debug_overlay.add_attribute(ego.kinematic, "acceleration", "Acceleration: ", None)
 
     hud_overlay = Overlay(
+        "hud_overlay",
         create_pg_surface_from_color_and_size(
             colors_dict["black"], (CommonConstants.WINDOW_WIDTH - 20, 80)
         ),
@@ -77,119 +80,106 @@ def process_keyboard_events(actions_while_key_pressed, actions_on_key_down):
             action.execute_action()
 
 
-def process_keyboard_events(actions_while_key_pressed, actions_on_key_down):
-    for event in pygame.event.get():
-        if event.type == pygame.locals.QUIT:
-            pygame.quit()
-            sys.exit()
-        elif event.type == pygame.locals.KEYDOWN:
-            for action in actions_on_key_down:
-                if event.key == action.trigger_key.key_identifier:
-                    action.execute_action()
+def main():
+    pygame.init()
+    game_window = GameWindow("Landing Game")
+    game_timing = GameTiming()
+    object_library = ObjectLibrary()
 
-    # check all key states and automatically perform all callbacks
-    key_press_state = pygame.key.get_pressed()
-    for action in actions_while_key_pressed:
-        trigger_action_given: bool = (
-            action.trigger_key.pressed
-            == key_press_state[action.trigger_key.key_identifier]
-        )
-        if trigger_action_given:
-            action.execute_action()
+    rocket_pos = Vec2d(
+        CommonConstants.WINDOW_WIDTH / 2, CommonConstants.WINDOW_HEIGHT / 2
+    )
+    rocket_mass = 1e5
+    ground_position = Vec2d(CommonConstants.WINDOW_WIDTH / 2, 500)
+    img_ego = create_pg_surface_from_color_and_size(
+        colors_dict["red"],
+        (meter_to_pixel(3.0), meter_to_pixel(8.0)),
+    )
+    img_ground = create_pg_surface_from_color_and_size(
+        colors_dict["green"], (CommonConstants.WINDOW_WIDTH, 10)
+    )
+
+    img_key_indicator_while_pressed = create_pg_surface_from_color_and_size(
+        colors_dict["cyan"], (20, 20)
+    )
+
+    key_indicator_while_pressed = LandingGameObject(
+        "key_indicator_while_pressed",
+        img_key_indicator_while_pressed,
+        Vec2d(CommonConstants.WINDOW_WIDTH - 50, CommonConstants.WINDOW_HEIGHT - 50),
+    )
+    img_key_indicator_on_down = create_pg_surface_from_color_and_size(
+        colors_dict["cyan"], (20, 20)
+    )
+
+    key_indicator_on_down = LandingGameObject(
+        "key_indicator_on_down",
+        img_key_indicator_on_down,
+        Vec2d(CommonConstants.WINDOW_WIDTH - 100, CommonConstants.WINDOW_HEIGHT - 50),
+    )
+
+    ego = Rocket("ego", img_ego, rocket_pos, rocket_mass)
+    ground = LandingGameObject("ground", img_ground, ground_position)
+    overlays = create_overlays(ground, ego, game_timing)
+
+    # predefine actions on key: keypress-states connected to actions that will be performed if state is given
+    color_key_indicator_blue_while_pressed = (
+        lambda: key_indicator_while_pressed.set_color(colors_dict["blue"])
+    )
+    color_key_indicator_cyan_while_pressed = (
+        lambda: key_indicator_while_pressed.set_color(colors_dict["cyan"])
+    )
+
+    color_key_indicator_blue_on_down = lambda: key_indicator_on_down.set_color(
+        colors_dict["blue"]
+    )
+    color_key_indicator_cyan_on_down = lambda: key_indicator_on_down.set_color(
+        colors_dict["cyan"]
+    )
+
+    toggle_overlay_visibility_on_down = lambda: overlays[0].toggle_visibility()
+
+    act_change_box_color_while_spacebar_pressed = LandingGameActionOnKey(
+        PygameKeyState(pygame.K_SPACE, True), color_key_indicator_blue_while_pressed
+    )
+    act_change_box_color_while_spacebar_not_pressed = LandingGameActionOnKey(
+        PygameKeyState(pygame.K_SPACE, False), color_key_indicator_cyan_while_pressed
+    )
+
+    act_change_box_color_on_spacebar_down = LandingGameActionOnKey(
+        PygameKeyState(pygame.K_SPACE, True), color_key_indicator_blue_on_down
+    )
+
+    act_toggle_overlay_visibility_on_v_down = LandingGameActionOnKey(
+        PygameKeyState(pygame.K_v, True), toggle_overlay_visibility_on_down
+    )
+
+    object_library.add_game_object(key_indicator_while_pressed)
+    object_library.add_game_object(key_indicator_on_down)
+    object_library.add_game_object(ego)
+    object_library.add_game_object(ground)
+    for overlay in overlays:
+        object_library.add_game_object(overlay)
+
+    # bundle all keystate -> action correlations into one list
+    actions_while_key_pressed = [
+        act_change_box_color_while_spacebar_pressed,
+        act_change_box_color_while_spacebar_not_pressed,
+    ]
+    actions_on_key_down = [
+        act_change_box_color_on_spacebar_down,
+        act_toggle_overlay_visibility_on_v_down,
+    ]
+
+    while True:
+        process_keyboard_events(actions_while_key_pressed, actions_on_key_down)
+        game_window.erase_screen()
+        object_library.update(CommonConstants.TIME_STEP)
+        object_library.blit(game_window.display)
+        game_timing.update(CommonConstants.TIME_STEP)
+        pygame.display.update()
+        game_window.clock.tick(game_window.fps)
 
 
-pygame.init()
-game_window = GameWindow("Landing Game")
-game_timing = GameTiming()
-rocket_pos = Vec2d(CommonConstants.WINDOW_WIDTH / 2, CommonConstants.WINDOW_HEIGHT / 2)
-rocket_mass = 1e5
-ground_position = Vec2d(CommonConstants.WINDOW_WIDTH / 2, 500)
-img_ego = create_pg_surface_from_color_and_size(
-    colors_dict["red"],
-    (meter_to_pixel(3.0), meter_to_pixel(8.0)),
-)
-img_ground = create_pg_surface_from_color_and_size(
-    colors_dict["green"], (CommonConstants.WINDOW_WIDTH, 10)
-)
-
-img_key_indicator_while_pressed = create_pg_surface_from_color_and_size(
-    colors_dict["cyan"], (20, 20)
-)
-
-key_indicator_while_pressed = LandingGameObject(
-    img_key_indicator_while_pressed,
-    Vec2d(CommonConstants.WINDOW_WIDTH - 50, CommonConstants.WINDOW_HEIGHT - 50),
-)
-img_key_indicator_on_down = create_pg_surface_from_color_and_size(
-    colors_dict["cyan"], (20, 20)
-)
-
-key_indicator_on_down = LandingGameObject(
-    img_key_indicator_on_down,
-    Vec2d(CommonConstants.WINDOW_WIDTH - 100, CommonConstants.WINDOW_HEIGHT - 50),
-)
-
-ego = Rocket(img_ego, rocket_pos, rocket_mass)
-ground = LandingGameObject(img_ground, ground_position)
-overlays = create_overlays(ground, ego, game_timing)
-
-# predefine actions on key: keypress-states connected to actions that will be performed if state is given
-color_key_indicator_blue_while_pressed = lambda: key_indicator_while_pressed.set_color(
-    colors_dict["blue"]
-)
-color_key_indicator_cyan_while_pressed = lambda: key_indicator_while_pressed.set_color(
-    colors_dict["cyan"]
-)
-
-color_key_indicator_blue_on_down = lambda: key_indicator_on_down.set_color(
-    colors_dict["blue"]
-)
-color_key_indicator_cyan_on_down = lambda: key_indicator_on_down.set_color(
-    colors_dict["cyan"]
-)
-
-toggle_overlay_visibility_on_down = lambda: overlays[0].toggle_visibility()
-
-act_change_box_color_while_spacebar_pressed = LandingGameActionOnKey(
-    PygameKeyState(pygame.K_SPACE, True), color_key_indicator_blue_while_pressed
-)
-act_change_box_color_while_spacebar_not_pressed = LandingGameActionOnKey(
-    PygameKeyState(pygame.K_SPACE, False), color_key_indicator_cyan_while_pressed
-)
-
-act_change_box_color_on_spacebar_down = LandingGameActionOnKey(
-    PygameKeyState(pygame.K_SPACE, True), color_key_indicator_blue_on_down
-)
-
-act_toggle_overlay_visibility_on_v_down = LandingGameActionOnKey(
-    PygameKeyState(pygame.K_v, True), toggle_overlay_visibility_on_down
-)
-
-
-obj_list = pygame.sprite.Group()
-obj_list.add(key_indicator_while_pressed)
-obj_list.add(key_indicator_on_down)
-obj_list.add(ego)
-obj_list.add(ground)
-for overlay in overlays:
-    obj_list.add(overlay)
-
-# bundle all keystate -> action correlations into one list
-actions_while_key_pressed = [
-    act_change_box_color_while_spacebar_pressed,
-    act_change_box_color_while_spacebar_not_pressed,
-]
-actions_on_key_down = [
-    act_change_box_color_on_spacebar_down,
-    act_toggle_overlay_visibility_on_v_down,
-]
-
-while True:
-    process_keyboard_events(actions_while_key_pressed, actions_on_key_down)
-    game_window.erase_screen()
-    for i, obj in enumerate(obj_list):
-        obj.update(CommonConstants.TIME_STEP)
-        game_window.display.blit(obj.image, obj.rect)
-    game_timing.update(CommonConstants.TIME_STEP)
-    pygame.display.update()
-    game_window.clock.tick(game_window.fps)
+if __name__ == "__main__":
+    main()

--- a/src/landing_game_object.py
+++ b/src/landing_game_object.py
@@ -2,6 +2,7 @@ import pygame
 
 from src.common_constants import Opacity
 from src.vec2d import Vec2d
+from src.object_library import ObjectLibrary
 
 
 class LandingGameObject(pygame.sprite.Sprite):
@@ -9,10 +10,13 @@ class LandingGameObject(pygame.sprite.Sprite):
 
     def __init__(
         self,
+        name: str,
         image: pygame.surface,
         pos_pixel: Vec2d = Vec2d(),
     ) -> None:
         super().__init__()
+        self.ID = ObjectLibrary().get_ID()
+        self.name = name
         self.rect: pygame.Rect = pygame.Surface.get_rect(image)
         self.rect.center = Vec2d(pos_pixel)
         self.add_pos_to_dict()

--- a/src/linear_physical_object.py
+++ b/src/linear_physical_object.py
@@ -8,6 +8,7 @@ from src.general_physics import meter_to_pixel, pixel_to_meter
 class LinearPhysicalObject(LandingGameObject, LinearKinematic):
     def __init__(
         self,
+        name: str,
         image: pygame.surface,
         pos: Vec2d,
         mass: float,
@@ -15,7 +16,7 @@ class LinearPhysicalObject(LandingGameObject, LinearKinematic):
         acceleration: Vec2d = Vec2d(),
     ):
 
-        LandingGameObject.__init__(self, image, pos)
+        LandingGameObject.__init__(self, name, image, pos)
         self.kinematic = LinearKinematic(mass, velocity, acceleration)
 
     def step(self, time_step_width: float) -> None:

--- a/src/object_library.py
+++ b/src/object_library.py
@@ -1,0 +1,40 @@
+import pygame
+
+
+class ObjectLibrary:
+    """
+    This class is responsible for generating unique IDs for objects.
+    """
+
+    def __init__(self):
+        self.game_objects = {}
+        self.next_ID = 0
+        self.used_IDs = []
+
+    def add_game_object(self, game_object):
+        """Adds a game object to the library."""
+        if game_object.name in self.game_objects:
+            raise ValueError("Object with this name already exists.")
+        if game_object.ID in self.used_IDs:
+            raise ValueError("Object with this ID already exists.")
+        self.game_objects[game_object.name] = game_object
+
+    def get_ID(self):
+        """Returns a unique ID for an object."""
+        self.next_ID += 1
+        if self.next_ID in self.used_IDs:
+            raise ValueError("ID already exists.")
+        self.used_IDs.append(self.next_ID)
+        return self.next_ID
+
+    def get_used_IDs(self):
+        """Returns all IDs that have been used so far."""
+        return self.used_IDs
+
+    def update(self, time_step):
+        for obj in self.game_objects.values():
+            obj.update(time_step)
+
+    def blit(self, display):
+        for obj in self.game_objects.values():
+            display.blit(obj.image, obj.rect)

--- a/src/overlay.py
+++ b/src/overlay.py
@@ -20,12 +20,13 @@ class Overlay(LandingGameObject):
 
     def __init__(
         self,
+        name: str,
         image: pygame.Surface,
         font: pygame.font.Font,
         position=(0, 0),
         alpha: int = Opacity.SEMI_TRANSPARENT,
     ):
-        super().__init__(image, position)
+        super().__init__(name, image, position)
         if not pygame.get_init():
             pygame.init()
         self.original_alpha = alpha

--- a/src/rocket.py
+++ b/src/rocket.py
@@ -6,10 +6,13 @@ from src.linear_physical_object import LinearPhysicalObject
 class Rocket(LinearPhysicalObject):
     def __init__(
         self,
+        name: str,
         image: pygame.surface,
         pos: Vec2d,
         mass: float,
         velocity: Vec2d = Vec2d(),
         acceleration: Vec2d = Vec2d(),
     ):
-        LinearPhysicalObject.__init__(self, image, pos, mass, velocity, acceleration)
+        LinearPhysicalObject.__init__(
+            self, name, image, pos, mass, velocity, acceleration
+        )

--- a/test/test_key_input_handling.py
+++ b/test/test_key_input_handling.py
@@ -61,6 +61,7 @@ def test_key_input_pressed_handling(keys_down_list, expected_color):
     )
 
     key_indicator_while_pressed = LandingGameObject(
+        "key_indicator_while_pressed",
         img_key_indicator_while_pressed,
         Vec2d(CommonConstants.WINDOW_WIDTH - 50, CommonConstants.WINDOW_HEIGHT - 50),
     )

--- a/test/test_landing_game_object.py
+++ b/test/test_landing_game_object.py
@@ -17,8 +17,12 @@ class TestLandingGameObject:
 
     def test_initialization(self, example_image):
         position_pixel = Vec2d(100, 90)
-        obj = LandingGameObject(image=example_image, pos_pixel=position_pixel)
+        obj = LandingGameObject(
+            "test_object", image=example_image, pos_pixel=position_pixel
+        )
 
+        assert obj.ID is not None
+        assert obj.name == "test_object"
         assert obj.pos == position_pixel
         assert obj.rect.width == example_image.get_width()
         assert obj.rect.height == example_image.get_height()

--- a/test/test_linear_physical_object.py
+++ b/test/test_linear_physical_object.py
@@ -27,6 +27,7 @@ class TestLinearPhysicalObject:
 
     def test_init(self, example_image):
         obj = LinearPhysicalObject(
+            name="test_object",
             image=example_image,
             pos=self.position_pixel,
             mass=self.mass,
@@ -34,12 +35,14 @@ class TestLinearPhysicalObject:
             acceleration=self.acceleration,
         )
         obj = LinearPhysicalObject(
+            name="test_object",
             image=example_image,
             pos=self.position_pixel,
             mass=self.mass,
             velocity=self.velocity,
         )
         obj = LinearPhysicalObject(
+            name="test_object",
             image=example_image,
             pos=self.position_pixel,
             mass=self.mass,
@@ -55,6 +58,7 @@ class TestLinearPhysicalObject:
         expected_new_velocity_meter = self.velocity + time_step * self.acceleration
 
         obj = LinearPhysicalObject(
+            name="test_object",
             image=example_image,
             pos=self.position_pixel,
             mass=self.mass,

--- a/test/test_object_library.py
+++ b/test/test_object_library.py
@@ -1,0 +1,54 @@
+import pytest
+from unittest.mock import MagicMock
+from src.object_library import ObjectLibrary
+
+
+class TestObjectLibrary:
+
+    @pytest.fixture
+    def object_library(self):
+        return ObjectLibrary()
+
+    def test_get_ID(self, object_library):
+        id1 = object_library.get_ID()
+        id2 = object_library.get_ID()
+        assert id1 == 1
+        assert id2 == 2
+
+        object_library.next_ID = 1
+        with pytest.raises(ValueError):
+            id3 = object_library.get_ID()
+
+    def test_get_used_IDs(self, object_library):
+        object_library.get_ID()
+        object_library.get_ID()
+        used_ids = object_library.get_used_IDs()
+        assert used_ids == [1, 2]
+
+    def test_add_game_object(self, object_library):
+        class MockObject:
+            def __init__(self, name, ID):
+                self.name = name
+                self.ID = ID
+
+        obj1 = MockObject("object1", 1)
+        object_library.add_game_object(obj1)
+        assert "object1" in object_library.game_objects
+
+        with pytest.raises(ValueError):
+            object_library.add_game_object(obj1)
+
+    def test_update(self, object_library):
+        mock_object = MagicMock()
+        mock_object.name = "object1"
+        object_library.add_game_object(mock_object)
+        object_library.update(0.1)
+        mock_object.update.assert_called_once_with(0.1)
+
+    def test_blit(self, object_library):
+        mock_object = MagicMock()
+        mock_object.name = "object1"
+        object_library.add_game_object(mock_object)
+        mock_display = MagicMock()
+        object_library.blit(mock_display)
+        mock_display.blit.assert_called_once_with(mock_object.image, mock_object.rect)

--- a/test/test_overlay.py
+++ b/test/test_overlay.py
@@ -9,7 +9,7 @@ def overlay():
     pygame.init()
     image = pygame.Surface((200, 100))
     font = pygame.font.Font(None, 36)
-    return Overlay(image, font)
+    return Overlay("test_overlay", image, font)
 
 
 def test_overlay_initialization(overlay):

--- a/test/test_rocket.py
+++ b/test/test_rocket.py
@@ -26,6 +26,7 @@ class TestRocket:
 
     def test_init(self, example_image):
         Rocket(
+            name="test_rocket",
             image=example_image,
             pos=self.position,
             mass=self.mass,
@@ -33,12 +34,14 @@ class TestRocket:
             acceleration=self.acceleration,
         )
         Rocket(
+            name="test_rocket",
             image=example_image,
             pos=self.position,
             mass=self.mass,
             velocity=self.velocity,
         )
         Rocket(
+            name="test_rocket",
             image=example_image,
             pos=self.position,
             mass=self.mass,
@@ -54,6 +57,7 @@ class TestRocket:
         expected_new_velocity_meter = self.velocity + time_step * self.acceleration
 
         obj = Rocket(
+            name="test_rocket",
             image=example_image,
             pos=self.position,
             mass=self.mass,


### PR DESCRIPTION
Added "name" and "ID" attribute to LandingGameObject class.
Made sure that all childs request a name and forward it to the init_ of their parent.
Made sure, every LandingGameObject creates a unique ID.

Added class "ObjectLibrary" as alternative to pygame.sprites.Group().
It contains a dictionary "game_objects" with the new "name" attibute as keys for easy access.
Also, it is used to create a unique ID and check if the chosen name is also unique.
Right now, this is kind of a redundancy because an object can be identified by a unique name and a unique ID. Maybe we don't need the ID.

Added tests for the "ObjectLibrary".
