### PR TITLE
27 add attribute name

### DIFF
--- a/main.py
+++ b/main.py
@@ -132,7 +132,9 @@ def main():
     )
 
     ego = Rocket(img_ego, rocket_pos, rocket_mass)
+    ego.name = "Rocket"
     ground = LandingGameObject(img_ground, ground_position)
+    ground.name = "Ground"
     overlays = create_overlays(ground, ego, game_timing)
 
     # predefine actions on key: keypress-states connected to actions that will be performed if state is given

--- a/src/landing_game_object.py
+++ b/src/landing_game_object.py
@@ -17,6 +17,7 @@ class LandingGameObject(pygame.sprite.Sprite):
     ) -> None:
         super().__init__()
         self.ID = self.ID_generator.assign_ID()
+        self.name: str = None
         self.rect: pygame.Rect = pygame.Surface.get_rect(image)
         self.rect.center = Vec2d(pos_pixel)
         self.add_pos_to_dict()
@@ -44,3 +45,11 @@ class LandingGameObject(pygame.sprite.Sprite):
 
     def add_pos_to_dict(self):
         self.__dict__.update({"pos": self.pos})
+
+    @property
+    def name(self) -> str:
+        return self.name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        self.name = name

--- a/src/landing_game_object.py
+++ b/src/landing_game_object.py
@@ -17,7 +17,7 @@ class LandingGameObject(pygame.sprite.Sprite):
     ) -> None:
         super().__init__()
         self.ID = self.ID_generator.assign_ID()
-        self.name: str = None
+        self._name: str = None
         self.rect: pygame.Rect = pygame.Surface.get_rect(image)
         self.rect.center = Vec2d(pos_pixel)
         self.add_pos_to_dict()
@@ -52,4 +52,4 @@ class LandingGameObject(pygame.sprite.Sprite):
 
     @name.setter
     def name(self, name: str) -> None:
-        self.name = name
+        self._name = name


### PR DESCRIPTION
How about implementing a "name" attribute in this way in branch #39 ?

Now it is optional to give a name to an object, but if appropriate, you can address an objekt like 
```python
for object in obj_list:
  if object.name == "Hugo":
    raise DudeError("No Hugo allowed")`
``` 