### PR TITLE
In 11 implement basic level design

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,58 +4,17 @@ from pygame.locals import *
 
 from src.general_physics import meter_to_pixel
 from src.game_window import GameWindow
-from src.rocket import Rocket
-from src.landing_game_object import LandingGameObject
 from src.vec2d import Vec2d
-from src.colors import colors_dict
-from src.common_constants import CommonConstants, GameFonts, Opacity
-from src.overlay import Overlay
+from src.common_constants import CommonConstants
 from src.game_timing import GameTiming
-from src.landing_game_action_on_key import PygameKeyState, LandingGameActionOnKey
-from src.landing_game_action_periodic import LandingGameActionEachFrame
-from src.landing_game_group import LandingGameGroup
+from src.scenario import Scenario
+from src.scenario_overlays import ScenarioOverlays
 
 
 def create_pg_surface_from_color_and_size(color, size):
     surf = pygame.Surface(size)
     surf.fill(color)
     return surf
-
-
-def create_overlays(ground, ego, game_timing):
-    debug_overlay = Overlay(
-        create_pg_surface_from_color_and_size(
-            colors_dict["black"], (CommonConstants.WINDOW_WIDTH / 3, 400)
-        ),
-        GameFonts.BASIC_FONT,
-        (10, 10),
-        Opacity.SEMI_TRANSPARENT,
-    )
-    debug_overlay.add_line("Debug Information:")
-    debug_overlay.add_line("")
-    debug_overlay.add_line("Ground")
-    debug_overlay.add_attribute(ground, "pos", "Altitude: ", None)
-
-    debug_overlay.add_line("")
-    debug_overlay.add_line("Rocket")
-    debug_overlay.add_attribute(ego, "pos", "Position: ", None)
-    debug_overlay.add_attribute(ego.kinematic, "velocity", "Velocity: ", None)
-    debug_overlay.add_attribute(ego.kinematic, "acceleration", "Acceleration: ", None)
-
-    hud_overlay = Overlay(
-        create_pg_surface_from_color_and_size(
-            colors_dict["black"], (CommonConstants.WINDOW_WIDTH - 20, 80)
-        ),
-        GameFonts.BASIC_FONT,
-        (10, CommonConstants.WINDOW_HEIGHT - 90),
-        Opacity.SEMI_TRANSPARENT,
-    )
-    hud_overlay.add_line("Time as float with 2 decimal places:")
-    hud_overlay.add_attribute(game_timing, "time", "Time: ", float)
-    hud_overlay.add_line("Time as int:")
-    hud_overlay.add_attribute(game_timing, "time", "Time: ", int)
-
-    return [debug_overlay, hud_overlay]
 
 
 def process_keyboard_events(actions_while_key_pressed, actions_on_key_down):
@@ -88,169 +47,26 @@ def main():
     pygame.init()
     game_window = GameWindow("Landing Game")
     game_timing = GameTiming()
-    rocket_pos = Vec2d(
-        CommonConstants.WINDOW_WIDTH / 2, CommonConstants.WINDOW_HEIGHT / 2
-    )
-    rocket_mass = CommonConstants.ROCKET_MASS
-    ground_position = Vec2d(CommonConstants.WINDOW_WIDTH / 2, 500)
-    img_ego = create_pg_surface_from_color_and_size(
-        colors_dict["red"],
-        (meter_to_pixel(3.0), meter_to_pixel(8.0)),
-    )
-    img_ground = create_pg_surface_from_color_and_size(
-        colors_dict["green"], (CommonConstants.WINDOW_WIDTH, 10)
-    )
-
-    img_key_indicator_while_pressed = create_pg_surface_from_color_and_size(
-        colors_dict["cyan"], (20, 20)
-    )
-    img_engine_fire = create_pg_surface_from_color_and_size(
-        pygame.Color("orange"), CommonConstants.EXHAUST_FIRE_DOWN_DIMENSIONS
-    )
-    key_indicator_while_pressed = LandingGameObject(
-        img_key_indicator_while_pressed,
-        Vec2d(CommonConstants.WINDOW_WIDTH - 50, CommonConstants.WINDOW_HEIGHT - 50),
-    )
-    img_key_indicator_on_down = create_pg_surface_from_color_and_size(
-        colors_dict["cyan"], (20, 20)
-    )
-
-    key_indicator_on_down = LandingGameObject(
-        img_key_indicator_on_down,
-        Vec2d(CommonConstants.WINDOW_WIDTH - 100, CommonConstants.WINDOW_HEIGHT - 50),
-    )
-
-    ego = Rocket(img_ego, rocket_pos, rocket_mass)
-    ego_engine_fire = LandingGameObject(
-        img_engine_fire,
-        pos=Vec2d(
-            ego.rect.midbottom[0],
-            ego.rect.midbottom[1]
-            + 0.5 * CommonConstants.EXHAUST_FIRE_DOWN_DIMENSIONS.y,
-        ),
-    )
-    ground = LandingGameObject(img_ground, ground_position)
-    overlays = create_overlays(ground, ego, game_timing)
-
-    # predefine actions on key: keypress-states connected to actions that will be performed if state is given
-    color_key_indicator_blue_while_pressed = (
-        lambda: key_indicator_while_pressed.set_color(colors_dict["blue"])
-    )
-    color_key_indicator_cyan_while_pressed = (
-        lambda: key_indicator_while_pressed.set_color(colors_dict["cyan"])
-    )
-
-    color_key_indicator_blue_on_down = lambda: key_indicator_on_down.set_color(
-        colors_dict["blue"]
-    )
-
-    toggle_overlay_visibility_on_down = lambda: overlays[0].toggle_visibility()
-
-    activate_ego_upwards_boost = lambda: ego.kinematic.external_forces.append(
-        CommonConstants.ROCKET_UPWARD_BOOST_FORCE_SCALAR * Vec2d(0, -1)
-    )
-
-    hide_engine_fire_up = lambda: ego_engine_fire.set_color(
-        pygame.Color("orange"),
-        alpha=Opacity.TRANSPARENT,
-    )
-    show_engine_fire_up = lambda: ego_engine_fire.set_color(
-        pygame.Color("orange"),
-        alpha=Opacity.OPAQUE,
-    )
-
-    glue_engine_fire_down_to_ego = lambda: setattr(
-        ego_engine_fire,
-        "pos",
-        Vec2d(
-            ego.rect.midbottom[0],
-            ego.rect.midbottom[1]
-            + 0.5 * CommonConstants.EXHAUST_FIRE_DOWN_DIMENSIONS.y,
-        ),
-    )
-
-    activate_left_engine_boost = lambda: ego.kinematic.external_forces.append(
-        CommonConstants.ROCKET_SIDEWAYS_BOOST_FORCE_SCALAR * Vec2d(-1, 0)
-    )
-    activate_right_engine_boost = lambda: ego.kinematic.external_forces.append(
-        CommonConstants.ROCKET_SIDEWAYS_BOOST_FORCE_SCALAR * Vec2d(1, 0)
-    )
-
-    act_change_box_color_while_spacebar_pressed = LandingGameActionOnKey(
-        PygameKeyState(pygame.K_SPACE, True), color_key_indicator_blue_while_pressed
-    )
-    act_change_box_color_while_spacebar_not_pressed = LandingGameActionOnKey(
-        PygameKeyState(pygame.K_SPACE, False), color_key_indicator_cyan_while_pressed
-    )
-
-    act_change_box_color_on_spacebar_down = LandingGameActionOnKey(
-        PygameKeyState(pygame.K_SPACE, True), color_key_indicator_blue_on_down
-    )
-
-    act_toggle_overlay_visibility_on_v_down = LandingGameActionOnKey(
-        PygameKeyState(pygame.K_v, True), toggle_overlay_visibility_on_down
-    )
-
-    act_boost_ego_up_on_upwards_key = LandingGameActionOnKey(
-        PygameKeyState(pygame.K_UP, True), activate_ego_upwards_boost
-    )
-    act_boost_ego_left_on_left_key = LandingGameActionOnKey(
-        PygameKeyState(pygame.K_LEFT, True), activate_left_engine_boost
-    )
-    act_boost_ego_up_on_rigth_key = LandingGameActionOnKey(
-        PygameKeyState(pygame.K_RIGHT, True), activate_right_engine_boost
-    )
-
-    act_show_engine_fire_up_on_upwards_key = LandingGameActionOnKey(
-        PygameKeyState(pygame.K_UP, True), show_engine_fire_up
-    )
-
-    act_hide_engine_fire_up_on_upwards_key_not_pressed = LandingGameActionOnKey(
-        PygameKeyState(pygame.K_UP, False), hide_engine_fire_up
-    )
-
-    obj_list = LandingGameGroup()
-    obj_list.add(key_indicator_while_pressed)
-    obj_list.add(key_indicator_on_down)
-    obj_list.add(ego)
-    obj_list.add(ground)
-    obj_list.add(ego_engine_fire)
-
-    for overlay in overlays:
-        obj_list.add(overlay)
-
-    act_glue_exhaust_flame_up_to_ego = LandingGameActionEachFrame(
-        glue_engine_fire_down_to_ego
-    )
-
-    # bundle all keystate -> action correlations into one list
-    actions_while_key_pressed = [
-        act_change_box_color_while_spacebar_pressed,
-        act_change_box_color_while_spacebar_not_pressed,
-        act_boost_ego_up_on_upwards_key,
-        act_boost_ego_left_on_left_key,
-        act_boost_ego_up_on_rigth_key,
-        act_show_engine_fire_up_on_upwards_key,
-        act_hide_engine_fire_up_on_upwards_key_not_pressed,
-    ]
-    actions_on_key_down = [
-        act_change_box_color_on_spacebar_down,
-        act_toggle_overlay_visibility_on_v_down,
-    ]
-
-    actions_each_frame = [act_glue_exhaust_flame_up_to_ego]
+    scenario = Scenario()
+    overlays = ScenarioOverlays(scenario, game_timing)
 
     while True:
-        process_each_frame_events(actions_each_frame)
-        process_keyboard_events(actions_while_key_pressed, actions_on_key_down)
+        process_each_frame_events(scenario.actions_each_frame)
+        process_keyboard_events(
+            scenario.actions_while_key_pressed, scenario.actions_on_key_down
+        )
         game_window.erase_screen()
+        ego = scenario.object_list.get_object_by_name("ego")
         ego.kinematic.external_forces.append(
             CommonConstants.ROCKET_MASS
             * Vec2d(0, CommonConstants.GRAVITATIONAL_FORCE_EARTH)
         )
-        for i, obj in enumerate(obj_list):
+        for obj in scenario.object_list:
             obj.update(CommonConstants.TIME_STEP)
             game_window.display.blit(obj.image, obj.rect)
+        for overlay in overlays.overlays:
+            overlay.update()
+            game_window.display.blit(overlay.image, overlay.rect)
         game_timing.update(CommonConstants.TIME_STEP)
         pygame.display.update()
         game_window.clock.tick(game_window.fps)

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -1,0 +1,144 @@
+import pygame
+
+from src.landing_game_group import LandingGameGroup
+from src.vec2d import Vec2d
+from src.common_constants import CommonConstants, Opacity
+from src.colors import colors_dict
+from src.general_physics import meter_to_pixel
+from src.rocket import Rocket
+from src.landing_game_object import LandingGameObject
+from src.landing_game_action_on_key import LandingGameActionOnKey, PygameKeyState
+from src.landing_game_action_periodic import LandingGameActionEachFrame
+from src.surface_creator import create_pg_surface_from_color_and_size
+
+
+class Scenario:
+    def __init__(self):
+        self.object_list = self.create_objects()
+        self.action_dict = self.create_actions(self.object_list)
+        (
+            self.actions_each_frame,
+            self.actions_while_key_pressed,
+            self.actions_on_key_down,
+        ) = self.create_key_bindings(self.action_dict)
+
+    def create_objects(self):
+        object_list = LandingGameGroup()
+
+        img_ego = create_pg_surface_from_color_and_size(
+            colors_dict["red"],
+            (meter_to_pixel(3.0), meter_to_pixel(8.0)),
+        )
+        rocket_pos = Vec2d(
+            CommonConstants.WINDOW_WIDTH / 2, CommonConstants.WINDOW_HEIGHT / 2
+        )
+        rocket_mass = CommonConstants.ROCKET_MASS
+        ego = Rocket(img_ego, rocket_pos, rocket_mass)
+        object_list.add(ego)
+        object_list.name_object("ego", ego)
+
+        img_ground = create_pg_surface_from_color_and_size(
+            colors_dict["green"], (CommonConstants.WINDOW_WIDTH, 10)
+        )
+        ground_position = Vec2d(CommonConstants.WINDOW_WIDTH / 2, 500)
+        ground = LandingGameObject(img_ground, ground_position)
+        object_list.add(ground)
+        object_list.name_object("ground", ground)
+
+        img_engine_fire = create_pg_surface_from_color_and_size(
+            pygame.Color("orange"), CommonConstants.EXHAUST_FIRE_DOWN_DIMENSIONS
+        )
+        ego_engine_fire = LandingGameObject(
+            img_engine_fire,
+            pos=Vec2d(
+                ego.rect.midbottom[0],
+                ego.rect.midbottom[1]
+                + 0.5 * CommonConstants.EXHAUST_FIRE_DOWN_DIMENSIONS.y,
+            ),
+        )
+        object_list.add(ego_engine_fire)
+        object_list.name_object("ego_engine_fire", ego_engine_fire)
+
+        return object_list
+
+    def create_actions(self, object_list):
+        action_dict = {}
+
+        ego = object_list.get_object_by_name("ego")
+        activate_ego_upwards_boost = lambda: ego.kinematic.external_forces.append(
+            CommonConstants.ROCKET_UPWARD_BOOST_FORCE_SCALAR * Vec2d(0, -1)
+        )
+        activate_left_engine_boost = lambda: ego.kinematic.external_forces.append(
+            CommonConstants.ROCKET_SIDEWAYS_BOOST_FORCE_SCALAR * Vec2d(-1, 0)
+        )
+        activate_right_engine_boost = lambda: ego.kinematic.external_forces.append(
+            CommonConstants.ROCKET_SIDEWAYS_BOOST_FORCE_SCALAR * Vec2d(1, 0)
+        )
+
+        ego_engine_fire = object_list.get_object_by_name("ego_engine_fire")
+        hide_engine_fire_up = lambda: ego_engine_fire.set_color(
+            pygame.Color("orange"),
+            alpha=Opacity.TRANSPARENT,
+        )
+        show_engine_fire_up = lambda: ego_engine_fire.set_color(
+            pygame.Color("orange"),
+            alpha=Opacity.OPAQUE,
+        )
+        glue_engine_fire_down_to_ego = lambda: setattr(
+            ego_engine_fire,
+            "pos",
+            Vec2d(
+                ego.rect.midbottom[0],
+                ego.rect.midbottom[1]
+                + 0.5 * CommonConstants.EXHAUST_FIRE_DOWN_DIMENSIONS.y,
+            ),
+        )
+
+        action_dict["activate_ego_upwards_boost"] = activate_ego_upwards_boost
+        action_dict["activate_left_engine_boost"] = activate_left_engine_boost
+        action_dict["activate_right_engine_boost"] = activate_right_engine_boost
+        action_dict["hide_engine_fire_up"] = hide_engine_fire_up
+        action_dict["show_engine_fire_up"] = show_engine_fire_up
+        action_dict["glue_engine_fire_down_to_ego"] = glue_engine_fire_down_to_ego
+
+        return action_dict
+
+    def create_key_bindings(self, action_dict):
+        actions_each_frame = []
+        actions_while_key_pressed = []
+        actions_on_key_down = []
+
+        act_glue_exhaust_flame_up_to_ego = LandingGameActionEachFrame(
+            action_dict["glue_engine_fire_down_to_ego"]
+        )
+
+        actions_each_frame.append(act_glue_exhaust_flame_up_to_ego)
+
+        act_boost_ego_up_on_upwards_key = LandingGameActionOnKey(
+            PygameKeyState(pygame.K_UP, True), action_dict["activate_ego_upwards_boost"]
+        )
+        act_boost_ego_left_on_left_key = LandingGameActionOnKey(
+            PygameKeyState(pygame.K_LEFT, True),
+            action_dict["activate_left_engine_boost"],
+        )
+        act_boost_ego_up_on_rigth_key = LandingGameActionOnKey(
+            PygameKeyState(pygame.K_RIGHT, True),
+            action_dict["activate_right_engine_boost"],
+        )
+
+        act_show_engine_fire_up_on_upwards_key = LandingGameActionOnKey(
+            PygameKeyState(pygame.K_UP, True), action_dict["show_engine_fire_up"]
+        )
+        act_hide_engine_fire_up_on_upwards_key_not_pressed = LandingGameActionOnKey(
+            PygameKeyState(pygame.K_UP, False), action_dict["hide_engine_fire_up"]
+        )
+
+        actions_while_key_pressed.append(act_boost_ego_up_on_upwards_key)
+        actions_while_key_pressed.append(act_boost_ego_left_on_left_key)
+        actions_while_key_pressed.append(act_boost_ego_up_on_rigth_key)
+        actions_while_key_pressed.append(act_show_engine_fire_up_on_upwards_key)
+        actions_while_key_pressed.append(
+            act_hide_engine_fire_up_on_upwards_key_not_pressed
+        )
+
+        return actions_each_frame, actions_while_key_pressed, actions_on_key_down

--- a/src/scenario_overlays.py
+++ b/src/scenario_overlays.py
@@ -1,0 +1,58 @@
+from src.common_constants import CommonConstants, GameFonts, Opacity
+from src.colors import colors_dict
+from src.overlay import Overlay
+from src.game_timing import GameTiming
+from src.surface_creator import create_pg_surface_from_color_and_size
+
+
+class ScenarioOverlays:
+    def __init__(self, scenario, *args):
+        self.scenario = scenario
+        self.args = args
+        self.overlays = self.create_overlays(scenario.object_list, args)
+
+    def create_overlays(self, object_list, args):
+        overlays = []
+        debug_overlay = Overlay(
+            create_pg_surface_from_color_and_size(
+                colors_dict["black"], (CommonConstants.WINDOW_WIDTH / 3, 400)
+            ),
+            GameFonts.BASIC_FONT,
+            (10, 10),
+            Opacity.SEMI_TRANSPARENT,
+        )
+        debug_overlay.add_line("Debug Information:")
+        debug_overlay.add_line("")
+        debug_overlay.add_line("Ground")
+        ground = object_list.get_object_by_name("ground")
+        debug_overlay.add_attribute(ground, "pos", "Altitude: ", None)
+
+        debug_overlay.add_line("")
+        debug_overlay.add_line("Rocket")
+        ego = object_list.get_object_by_name("ego")
+        debug_overlay.add_attribute(ego, "pos", "Position: ", None)
+        debug_overlay.add_attribute(ego.kinematic, "velocity", "Velocity: ", None)
+        debug_overlay.add_attribute(
+            ego.kinematic, "acceleration", "Acceleration: ", None
+        )
+        overlays.append(debug_overlay)
+
+        hud_overlay = Overlay(
+            create_pg_surface_from_color_and_size(
+                colors_dict["black"], (CommonConstants.WINDOW_WIDTH - 20, 80)
+            ),
+            GameFonts.BASIC_FONT,
+            (10, CommonConstants.WINDOW_HEIGHT - 90),
+            Opacity.SEMI_TRANSPARENT,
+        )
+        for arg in args:
+            if isinstance(arg, GameTiming):
+                game_timing = arg
+                break
+        if game_timing is None:
+            raise ValueError("GameTiming object not found in args")
+        hud_overlay.add_line("Time:")
+        hud_overlay.add_attribute(game_timing, "time", "Time: ", float)
+        overlays.append(hud_overlay)
+
+        return overlays

--- a/src/surface_creator.py
+++ b/src/surface_creator.py
@@ -1,0 +1,7 @@
+import pygame
+
+
+def create_pg_surface_from_color_and_size(color, size):
+    surf = pygame.Surface(size)
+    surf.fill(color)
+    return surf

--- a/test/test_scenario.py
+++ b/test/test_scenario.py
@@ -1,0 +1,88 @@
+import pytest
+import pygame
+from src.scenario import Scenario
+from src.common_constants import CommonConstants, Opacity
+from src.vec2d import Vec2d
+
+
+@pytest.fixture
+def scenario():
+    pygame.init()
+    scenario_instance = Scenario()
+    yield scenario_instance
+    pygame.quit()
+
+
+def test_create_objects(scenario):
+    object_list = scenario.object_list
+    assert len(object_list) == 3
+
+    ego = object_list.get_object_by_name("ego")
+    assert ego is not None
+    assert isinstance(ego, pygame.sprite.Sprite)
+    assert ego.rect.center == (
+        CommonConstants.WINDOW_WIDTH / 2,
+        CommonConstants.WINDOW_HEIGHT / 2,
+    )
+
+    ground = object_list.get_object_by_name("ground")
+    assert ground is not None
+    assert isinstance(ground, pygame.sprite.Sprite)
+    assert ground.rect.center == (CommonConstants.WINDOW_WIDTH / 2, 500)
+
+    ego_engine_fire = object_list.get_object_by_name("ego_engine_fire")
+    assert ego_engine_fire is not None
+    assert isinstance(ego_engine_fire, pygame.sprite.Sprite)
+    assert ego_engine_fire.rect.center == (
+        ego.rect.midbottom[0],
+        ego.rect.midbottom[1] + 0.5 * CommonConstants.EXHAUST_FIRE_DOWN_DIMENSIONS.y,
+    )
+
+
+def test_create_actions(scenario):
+    action_dict = scenario.action_dict
+    assert "activate_ego_upwards_boost" in action_dict
+    assert "activate_left_engine_boost" in action_dict
+    assert "activate_right_engine_boost" in action_dict
+    assert "hide_engine_fire_up" in action_dict
+    assert "show_engine_fire_up" in action_dict
+    assert "glue_engine_fire_down_to_ego" in action_dict
+
+
+def test_create_key_bindings(scenario):
+    actions_each_frame, actions_while_key_pressed, actions_on_key_down = (
+        scenario.create_key_bindings(scenario.action_dict)
+    )
+
+    assert len(actions_each_frame) == 1
+    assert len(actions_while_key_pressed) == 5
+    assert len(actions_on_key_down) == 0
+
+
+def test_ego_upwards_boost(scenario):
+    ego = scenario.object_list.get_object_by_name("ego")
+    initial_force_count = len(ego.kinematic.external_forces)
+    scenario.action_dict["activate_ego_upwards_boost"]()
+    assert len(ego.kinematic.external_forces) == initial_force_count + 1
+
+
+def test_left_engine_boost(scenario):
+    ego = scenario.object_list.get_object_by_name("ego")
+    initial_force_count = len(ego.kinematic.external_forces)
+    scenario.action_dict["activate_left_engine_boost"]()
+    assert len(ego.kinematic.external_forces) == initial_force_count + 1
+
+
+def test_right_engine_boost(scenario):
+    ego = scenario.object_list.get_object_by_name("ego")
+    initial_force_count = len(ego.kinematic.external_forces)
+    scenario.action_dict["activate_right_engine_boost"]()
+    assert len(ego.kinematic.external_forces) == initial_force_count + 1
+
+
+def test_show_hide_engine_fire(scenario):
+    ego_engine_fire = scenario.object_list.get_object_by_name("ego_engine_fire")
+    scenario.action_dict["show_engine_fire_up"]()
+    assert ego_engine_fire.image.get_alpha() == Opacity.OPAQUE
+    scenario.action_dict["hide_engine_fire_up"]()
+    assert ego_engine_fire.image.get_alpha() == Opacity.TRANSPARENT

--- a/test/test_scenario_overlays.py
+++ b/test/test_scenario_overlays.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import Mock, patch
+from src.scenario_overlays import ScenarioOverlays
+from src.colors import colors_dict
+from src.overlay import Overlay
+from src.game_timing import GameTiming
+from src.surface_creator import create_pg_surface_from_color_and_size
+
+
+@pytest.fixture
+@patch("src.surface_creator.create_pg_surface_from_color_and_size")
+def setup(mock_create_surface):
+    mock_scenario = Mock()
+    mock_object_list = Mock()
+    mock_scenario.object_list = mock_object_list
+
+    mock_ground = Mock()
+    mock_ego = Mock()
+    mock_kinematic = Mock()
+    mock_ego.kinematic = mock_kinematic
+
+    mock_game_timing = Mock(spec=GameTiming)
+    mock_game_timing.time = 123.456
+
+    mock_create_surface.return_value = Mock()
+
+    return {
+        "mock_scenario": mock_scenario,
+        "mock_game_timing": mock_game_timing,
+        "mock_ground": mock_ground,
+        "mock_ego": mock_ego,
+        "mock_kinematic": mock_kinematic,
+    }
+
+
+def test_create_overlays(setup):
+    scenario_overlays = ScenarioOverlays(
+        setup["mock_scenario"], setup["mock_game_timing"]
+    )
+
+    assert len(scenario_overlays.overlays) == 2
+
+    debug_overlay = scenario_overlays.overlays[0]
+    assert isinstance(debug_overlay, Overlay)
+
+    hud_overlay = scenario_overlays.overlays[1]
+    assert isinstance(hud_overlay, Overlay)


### PR DESCRIPTION
# Overview
A contribution to the larger project of removing stuff from main.py to appropriate files where it can stay while the project grows.
In this case, it addresses mostly the creation and actions of the objects shown on screen.

# What i did
Instead of creating these things in main.py, now there is a class "Level" that has 4 containers:
* object_list: a list that contains the objects for this level
* action_dict: a dict that contains the actions which can be performed in this level
* actions_while_key_pressed: a list that contains the keybindingsfor the actions in this level
* actions_on_key_down: a list that contains the keybindingsfor the actions in this level

On initialisation, each container is filled with the stuff that is defined in separate functions.
In a logic chain, the creation of objects doesn't need parameters, actions need objects, and the keybindings need actions.

# How to work with it
As it is implemented now, new things can be added by adding code for the creation of objects, actions and keybindings to the appropiate function. This way, these 3 things are in one file, separated visually, and connected automatically.

# What to change in the future
Until now, it has the same functionality as before. 
But is has the potential to:
* Implement a possibility to create multiple levels
* Implement a "Basic Level" that has the minimal functionality that is required for each level and can be expanded as desired