### PR TITLE
Added attribute external_forces_last_frame to LinearPhysicalObject

### DIFF
--- a/src/common_constants.py
+++ b/src/common_constants.py
@@ -32,6 +32,10 @@ class GameFonts:
     BASIC_FONT_SIZE: int = 16
     BASIC_FONT = pygame.font.SysFont(BASIC_FONT_TYPE, BASIC_FONT_SIZE)
 
+    SMALL_FONT_TYPE: str = "Calibri"
+    SMALL_FONT_SIZE: int = 12
+    SMALL_FONT = pygame.font.SysFont(SMALL_FONT_TYPE, SMALL_FONT_SIZE)
+
 
 @dataclass(frozen=True)
 class Opacity:

--- a/src/linear_physical_object.py
+++ b/src/linear_physical_object.py
@@ -24,6 +24,7 @@ class LinearPhysicalObject(LandingGameObject, MotionState):
         self.kinematic = MotionState(
             pixel_to_meter(pos), mass, velocity, external_forces
         )
+        self.external_forces_last_frame: list = [Vec2d()]
 
     def step(self, time_step_width: float) -> None:
         """Perform timestep: update position and velocity
@@ -46,6 +47,7 @@ class LinearPhysicalObject(LandingGameObject, MotionState):
         new_velocity = self.kinematic.velocity + time_step_width * acceleration
         self.kinematic.velocity = new_velocity
         self.pos = meter_to_pixel(new_pos_meter)
+        self.external_forces_last_frame = self.kinematic.external_forces
         self.kinematic.external_forces = []
 
     def update(self, time_step):

--- a/src/overlay.py
+++ b/src/overlay.py
@@ -152,7 +152,7 @@ class Overlay(LandingGameObject):
             isinstance(i, Vec2d) for i in display_value
         ):
             display_value = [
-                f"Vec2d({force.x:.2f}, {force.y:.2f})" for force in display_value
+                f"({force.x:.2f}, {force.y:.2f})" for force in display_value
             ]
 
         return display_value

--- a/src/scenario_overlays.py
+++ b/src/scenario_overlays.py
@@ -15,9 +15,9 @@ class ScenarioOverlays:
         overlays = []
         debug_overlay = Overlay(
             create_pg_surface_from_color_and_size(
-                colors_dict["black"], (CommonConstants.WINDOW_WIDTH / 3, 400)
+                colors_dict["black"], (CommonConstants.WINDOW_WIDTH - 20, 400)
             ),
-            GameFonts.BASIC_FONT,
+            GameFonts.SMALL_FONT,
             (10, 10),
             Opacity.SEMI_TRANSPARENT,
         )
@@ -33,7 +33,7 @@ class ScenarioOverlays:
         debug_overlay.add_attribute(ego, "pos", "Position", None)
         debug_overlay.add_attribute(ego.kinematic, "velocity", "Velocity", None)
         debug_overlay.add_attribute(
-            ego.kinematic, "external_forces", "External Forces", None
+            ego, "external_forces_last_frame", "External Forces", None
         )
         overlays.append(debug_overlay)
 


### PR DESCRIPTION
Now it is possible to show the list of external_forces in the overlay.

Still not great, for example having an extra variable external_forces_last_frame just for this purpose lacks of elegance. If you can think of a better solution, i would be happy to change this part.

Also, right now, this list can only be displayed in one line. So long lists could be outside the window range. By removing unnecessary characters, introducing a smaller font and increasing the with of the overlay, there is now enough space do display about about 6 to 7 forces. Since this should be enough for some time and implementing line breaks would require an massive overhaul of the Overlay, i would leave it as it is right now.