### PR TITLE
IN-45 calculate jerk on ego <-> ground crash

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import pygame
 from pygame.locals import *
 
-from src.general_physics import objects_collide, apply_vertical_collision_damage
+from src.general_physics import objects_collide
 from src.game_window import GameWindow
 from src.vec2d import Vec2d
 from src.common_constants import CommonConstants
@@ -11,6 +11,7 @@ from src.scenario_overlays import ScenarioOverlays
 from src.event_handler import EventHandler
 from src.scenario_termination import ScenarioTermination
 from src.scenario_results_struct import ScenarioState
+from src.rocket import Rocket
 
 
 def main():
@@ -48,7 +49,7 @@ def main():
             game_window.display.blit(overlay.image, overlay.rect)
         ground = scenario.object_list.get_object_by_name("ground")
         if objects_collide(ego, ground):
-            apply_vertical_collision_damage(ego, ground)
+            ego.apply_vertical_collision_damage(ground)
         game_timing.update(CommonConstants.TIME_STEP)
         pygame.display.update()
         game_window.clock.tick(game_window.fps)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import pygame
 from pygame.locals import *
 
-from src.general_physics import objects_collide, apply_collision_damage
+from src.general_physics import objects_collide, apply_vertical_collision_damage
 from src.game_window import GameWindow
 from src.vec2d import Vec2d
 from src.common_constants import CommonConstants
@@ -48,7 +48,7 @@ def main():
             game_window.display.blit(overlay.image, overlay.rect)
         ground = scenario.object_list.get_object_by_name("ground")
         if objects_collide(ego, ground):
-            apply_collision_damage(ego, ground)
+            apply_vertical_collision_damage(ego, ground)
         game_timing.update(CommonConstants.TIME_STEP)
         pygame.display.update()
         game_window.clock.tick(game_window.fps)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import pygame
 from pygame.locals import *
 
-from src.general_physics import objects_collide
+from src.general_physics import objects_collide, apply_collision_damage
 from src.game_window import GameWindow
 from src.vec2d import Vec2d
 from src.common_constants import CommonConstants
@@ -27,7 +27,7 @@ def main():
 
     scenario_termination = ScenarioTermination(scenario)
 
-    while scenario.termination_condition() is False:
+    while not scenario.termination_condition():
         event_handler.process_events(
             scenario.actions_each_frame,
             scenario.actions_while_key_pressed,
@@ -46,13 +46,16 @@ def main():
         for overlay in overlays.overlays:
             overlay.update()
             game_window.display.blit(overlay.image, overlay.rect)
+        ground = scenario.object_list.get_object_by_name("ground")
+        if objects_collide(ego, ground):
+            apply_collision_damage(ego, ground)
         game_timing.update(CommonConstants.TIME_STEP)
         pygame.display.update()
         game_window.clock.tick(game_window.fps)
 
     final_elapsed_time = game_timing.time
     scenario_termination.assign_values_to_scenario_result_struct(
-        ScenarioState.SUCCESS, final_elapsed_time, 456.0
+        ScenarioState.SUCCESS, final_elapsed_time, ego.health
     )
     result_struct = scenario_termination.result_dict
     scenario_termination.execute_termination()

--- a/src/common_constants.py
+++ b/src/common_constants.py
@@ -16,6 +16,8 @@ class CommonConstants:
     TIME_STEP: float = 1 / FPS  # seconds
     WINDOW_WIDTH: int = 800
     WINDOW_HEIGHT: int = 600
+    EGO_INITIAL_HEALTH: float = 100
+    EGO_DAMAGE_SENSITIVITY: float = 5
 
 
 @dataclass(frozen=True)

--- a/src/general_physics.py
+++ b/src/general_physics.py
@@ -1,6 +1,6 @@
 from src.common_constants import CommonConstants
 from src.vec2d import Vec2d
-
+from src.landing_game_object import LandingGameObject
 
 pixel_to_meter_ratio: float = CommonConstants.PIXEL_TO_METER
 meter_to_pixel_ratio: float = CommonConstants.METER_TO_PIXEL
@@ -35,24 +35,5 @@ def meter_to_pixel(*args) -> float:
     return res
 
 
-def objects_collide(obj1, obj2) -> bool:
+def objects_collide(obj1: LandingGameObject, obj2: LandingGameObject) -> bool:
     return obj1.rect.colliderect(obj2.rect)
-
-
-def __damage_object(obj, damage: float):
-    obj.health = max(obj.health - damage, 0)
-
-
-def apply_vertical_collision_damage(ego, challenger):
-    """given ego and challenger collide vertically,
-    apply damage to ego based on vertical velocity difference
-
-    Args:
-        ego (Rocket): Object that has a velocity and health
-        challenger (LinearPhysicalObject): Object that has a velocity
-    """
-    ego_vertical_v = ego.kinematic.velocity.y
-    challenger_vertical_v = challenger.kinematic.velocity.y
-    vertical_crash_velocity = abs(ego_vertical_v - challenger_vertical_v)
-    damage = vertical_crash_velocity * CommonConstants.EGO_DAMAGE_SENSITIVITY
-    __damage_object(ego, damage)

--- a/src/general_physics.py
+++ b/src/general_physics.py
@@ -43,7 +43,14 @@ def __damage_object(obj, damage: float):
     obj.health = max(obj.health - damage, 0)
 
 
-def apply_collision_damage(ego, challenger):
+def apply_vertical_collision_damage(ego, challenger):
+    """given ego and challenger collide vertically,
+    apply damage to ego based on vertical velocity difference
+
+    Args:
+        ego (Rocket): Object that has a velocity and health
+        challenger (LinearPhysicalObject): Object that has a velocity
+    """
     ego_vertical_v = ego.kinematic.velocity.y
     challenger_vertical_v = challenger.kinematic.velocity.y
     vertical_crash_velocity = abs(ego_vertical_v - challenger_vertical_v)

--- a/src/general_physics.py
+++ b/src/general_physics.py
@@ -4,7 +4,7 @@ from src.vec2d import Vec2d
 
 pixel_to_meter_ratio: float = CommonConstants.PIXEL_TO_METER
 meter_to_pixel_ratio: float = CommonConstants.METER_TO_PIXEL
-timestep_size: float = 1 / 60
+timestep_size: float = 1 / CommonConstants.FPS
 
 
 def pixel_to_meter(*args) -> float:
@@ -37,3 +37,15 @@ def meter_to_pixel(*args) -> float:
 
 def objects_collide(obj1, obj2) -> bool:
     return obj1.rect.colliderect(obj2.rect)
+
+
+def __damage_object(obj, damage: float):
+    obj.health = max(obj.health - damage, 0)
+
+
+def apply_collision_damage(ego, challenger):
+    ego_vertical_v = ego.kinematic.velocity.y
+    challenger_vertical_v = challenger.kinematic.velocity.y
+    vertical_crash_velocity = abs(ego_vertical_v - challenger_vertical_v)
+    damage = vertical_crash_velocity * CommonConstants.EGO_DAMAGE_SENSITIVITY
+    __damage_object(ego, damage)

--- a/src/landing_game_object.py
+++ b/src/landing_game_object.py
@@ -19,7 +19,7 @@ class LandingGameObject(pygame.sprite.Sprite):
 
         Args:
             image (pygame.surface): pygame.surface that defines the object's visual representation
-            pos (Vec2d, optional): 2d Position in pixel. (0,0) represents left top corner. Defaults to Vec2d().
+            pos (Vec2d, optional): 2d Position in pixel. (0,0) represents image center. Defaults to Vec2d().
         """
         super().__init__()
         self.__id = self.id_generator.generate_new_id()

--- a/src/rocket.py
+++ b/src/rocket.py
@@ -1,6 +1,7 @@
 import pygame
 from src.vec2d import Vec2d
 from src.linear_physical_object import LinearPhysicalObject
+from src.common_constants import CommonConstants
 
 
 class Rocket(LinearPhysicalObject):
@@ -13,3 +14,4 @@ class Rocket(LinearPhysicalObject):
         external_forces: Vec2d = [Vec2d()],
     ):
         LinearPhysicalObject.__init__(self, image, pos, mass, velocity, external_forces)
+        self.health: int = CommonConstants.EGO_INITIAL_HEALTH

--- a/src/rocket.py
+++ b/src/rocket.py
@@ -15,3 +15,20 @@ class Rocket(LinearPhysicalObject):
     ):
         LinearPhysicalObject.__init__(self, image, pos, mass, velocity, external_forces)
         self.health: int = CommonConstants.EGO_INITIAL_HEALTH
+
+    def apply_vertical_collision_damage(self, challenger) -> None:
+        """given ego and challenger collide vertically,
+        apply damage to ego based on vertical velocity difference
+
+        Args:
+            ego (): Object that has a velocity and health
+            challenger (LinearPhysicalObject): Object that has a velocity
+        """
+        ego_vertical_v = self.kinematic.velocity.y
+        challenger_vertical_v = challenger.kinematic.velocity.y
+        vertical_crash_velocity = abs(ego_vertical_v - challenger_vertical_v)
+        damage = vertical_crash_velocity * CommonConstants.EGO_DAMAGE_SENSITIVITY
+        self.__damage_object(damage)
+
+    def __damage_object(self, damage: float) -> None:
+        self.health = max(self.health - damage, 0)

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -10,6 +10,7 @@ from src.landing_game_object import LandingGameObject
 from src.landing_game_action_on_key import LandingGameActionOnKey, PygameKeyState
 from src.landing_game_action_periodic import LandingGameActionEachFrame
 from src.surface_creator import create_pg_surface_from_color_and_size
+from src.linear_physical_object import LinearPhysicalObject
 
 
 class Scenario:
@@ -42,7 +43,13 @@ class Scenario:
             colors_dict["green"], (CommonConstants.WINDOW_WIDTH, 10)
         )
         ground_position = Vec2d(CommonConstants.WINDOW_WIDTH / 2, 500)
-        ground = LandingGameObject(img_ground, ground_position)
+        ground = LinearPhysicalObject(
+            img_ground,
+            ground_position,
+            mass=1e10,
+            velocity=Vec2d(0, 0),
+            external_forces=[Vec2d(0, 0)],
+        )
         object_list.add(ground)
         object_list.name_object("ground", ground)
 

--- a/src/scenario_overlays.py
+++ b/src/scenario_overlays.py
@@ -35,6 +35,7 @@ class ScenarioOverlays:
         debug_overlay.add_attribute(
             ego.kinematic, "external_forces", "External Forces", None
         )
+        debug_overlay.add_attribute(ego, "health", "Health: ", None)
         overlays.append(debug_overlay)
 
         hud_overlay = Overlay(

--- a/src/scenario_termination.py
+++ b/src/scenario_termination.py
@@ -1,5 +1,5 @@
 from src.scenario import Scenario
-from src.scenario_results_struct import ScenarioResultStruct, ScenarioState
+from src.scenario_results_struct import ScenarioState
 
 
 class ScenarioTermination:
@@ -9,6 +9,7 @@ class ScenarioTermination:
         self.result_dict: dict = {}
 
     def execute_termination(self):
+
         self.termination_stdout_message()
 
     def termination_stdout_message(self):

--- a/src/scenario_termination.py
+++ b/src/scenario_termination.py
@@ -9,7 +9,6 @@ class ScenarioTermination:
         self.result_dict: dict = {}
 
     def execute_termination(self):
-
         self.termination_stdout_message()
 
     def termination_stdout_message(self):

--- a/test/test_general_physics.py
+++ b/test/test_general_physics.py
@@ -5,13 +5,10 @@ from src.general_physics import (
     pixel_to_meter,
     timestep_size,
     objects_collide,
-    apply_vertical_collision_damage,
 )
 from src.common_constants import CommonConstants
 from src.vec2d import Vec2d
 from src.landing_game_object import LandingGameObject
-from src.linear_physical_object import LinearPhysicalObject
-from src.rocket import Rocket
 from src.common_constants import CommonConstants
 
 test_vector = Vec2d(1.2, 3.5)
@@ -99,26 +96,3 @@ def test_objects_collide():
 
     assert objects_collide(obj_center, obj_top_left_distant) == False
     assert objects_collide(obj_center, obj_top_right_close) == True
-
-
-def test_apply_collision_damage():
-    ego_relative_speed = 10
-    ego = Rocket(
-        image=pygame.Surface((10, 10)),
-        pos=Vec2d(0, 0),
-        mass=1,
-        velocity=Vec2d(0, ego_relative_speed),
-        external_forces=[Vec2d(0, 0)],
-    )
-    assert ego.health == CommonConstants.EGO_INITIAL_HEALTH
-
-    challenger = LinearPhysicalObject(
-        image=pygame.Surface((10, 10)),
-        pos=Vec2d(9, 0),
-        mass=1,
-        velocity=Vec2d(0, 0),
-        external_forces=[Vec2d(0, 0)],
-    )
-    apply_vertical_collision_damage(ego, challenger)
-    expected_damage = ego_relative_speed * CommonConstants.EGO_DAMAGE_SENSITIVITY
-    assert ego.health == CommonConstants.EGO_INITIAL_HEALTH - expected_damage

--- a/test/test_rocket.py
+++ b/test/test_rocket.py
@@ -7,6 +7,7 @@ from src.dimensions2d import Dimensions2D
 from src.vec2d import Vec2d
 from src.general_physics import pixel_to_meter, meter_to_pixel
 from src.common_constants import CommonConstants
+from src.linear_physical_object import LinearPhysicalObject
 
 
 @pytest.fixture
@@ -72,3 +73,25 @@ class TestRocket:
         assert obj.kinematic.velocity == expected_new_velocity_meter
         with pytest.raises(ValueError):
             obj.step(non_admissible_time_step)
+
+    def test_apply_collision_damage(self):
+        ego_relative_speed = 10
+        ego = Rocket(
+            image=pygame.Surface((10, 10)),
+            pos=Vec2d(0, 0),
+            mass=1,
+            velocity=Vec2d(0, ego_relative_speed),
+            external_forces=[Vec2d(0, 0)],
+        )
+        assert ego.health == CommonConstants.EGO_INITIAL_HEALTH
+
+        challenger = LinearPhysicalObject(
+            image=pygame.Surface((10, 10)),
+            pos=Vec2d(9, 0),
+            mass=1,
+            velocity=Vec2d(0, 0),
+            external_forces=[Vec2d(0, 0)],
+        )
+        ego.apply_vertical_collision_damage(challenger)
+        expected_damage = ego_relative_speed * CommonConstants.EGO_DAMAGE_SENSITIVITY
+        assert ego.health == CommonConstants.EGO_INITIAL_HEALTH - expected_damage


### PR DESCRIPTION
## Description
The game should reward soft landings and punish rough bumpy ones. In this prove of concept, therefore the game terminates once ego-rocket hits the ground and the vertical collision speed is determined. Final score is calculated considering this collision speed

## Changes
* smaller improvements (eg. calculate framerate from already defined constant values instead of from number)
* add capability of calculate vertical collision speed of ego and challenger object to rocket class

## How to test
### Manual qualitative test:
start main.py and let ego collide with ground -> game is terminated, collision speed influences final score (faster when crash -> smaller score")
### Unit tests
* `test/test_rocket.py`
* `test/test_general_physics`