### PR TITLE
Feature/in 66 create fuel consumption on boost activation

### DIFF
--- a/src/common_constants.py
+++ b/src/common_constants.py
@@ -16,6 +16,8 @@ class CommonConstants:
     TIME_STEP: float = 1 / FPS  # seconds
     WINDOW_WIDTH: int = 800
     WINDOW_HEIGHT: int = 600
+    FUEL_INITIAL_AMOUNT: float = 1e5
+    FUEL_CONSUMPTION_RATE: float = 1e-4
 
 
 @dataclass(frozen=True)

--- a/src/linear_physical_object.py
+++ b/src/linear_physical_object.py
@@ -32,18 +32,21 @@ class LinearPhysicalObject(LandingGameObject, MotionState):
         Args:
             time_step_width (float): len of timestep that should be simulated
         """
-        resulting_external_force = sum(self.kinematic.external_forces)
-        acceleration = +(1 / self.kinematic.mass) * resulting_external_force
+        self.__update_kinetics(time_step_width)
 
         if time_step_width < 0:
             raise ValueError(
                 f"Negative time {time_step_width} handed to LinearPhysicalObject.step. Only positive time admissible!"
             )
+
+    def __update_kinetics(self, time_step: float) -> None:
+        resulting_external_force = sum(self.kinematic.external_forces)
+        acceleration = +(1 / self.kinematic.mass) * resulting_external_force
         new_pos_meter = Vec2d(
-            self.kinematic.pos_meter_precise + time_step_width * self.kinematic.velocity
+            self.kinematic.pos_meter_precise + time_step * self.kinematic.velocity
         )
         self.kinematic.pos_meter_precise = new_pos_meter
-        new_velocity = self.kinematic.velocity + time_step_width * acceleration
+        new_velocity = self.kinematic.velocity + time_step * acceleration
         self.kinematic.velocity = new_velocity
         self.pos = meter_to_pixel(new_pos_meter)
         self.kinematic.external_forces = []

--- a/src/rocket.py
+++ b/src/rocket.py
@@ -1,6 +1,7 @@
 import pygame
 from src.vec2d import Vec2d
 from src.linear_physical_object import LinearPhysicalObject
+from src.common_constants import CommonConstants
 
 
 class Rocket(LinearPhysicalObject):
@@ -13,3 +14,25 @@ class Rocket(LinearPhysicalObject):
         external_forces: Vec2d = [Vec2d()],
     ):
         LinearPhysicalObject.__init__(self, image, pos, mass, velocity, external_forces)
+        self.fuel = CommonConstants.FUEL_INITIAL_AMOUNT
+
+    def step(self, time_step_width: float) -> None:
+        """Perform timestep: update position and velocity
+        from current acceleration and velocity after timestep of time_step_with (s)
+
+        Args:
+            time_step_width (float): len of timestep that should be simulated
+        """
+        super().step(time_step_width)
+
+    def activate_engine(self, force_vector: Vec2d) -> None:
+        if self.fuel > 0:
+            self.kinematic.external_forces.append(force_vector)
+            self.__decrease_fuel(
+                force_vector.norm() * CommonConstants.FUEL_CONSUMPTION_RATE
+            )
+        else:
+            print("ENGINE NOT USABLE, FUEL EMPTY !!!")
+
+    def __decrease_fuel(self, amount: float) -> None:
+        self.fuel = max(0, self.fuel - amount)

--- a/src/scenario.py
+++ b/src/scenario.py
@@ -66,13 +66,13 @@ class Scenario:
         action_dict = {}
 
         ego = object_list.get_object_by_name("ego")
-        activate_ego_upwards_boost = lambda: ego.kinematic.external_forces.append(
+        activate_ego_upwards_boost = lambda: ego.activate_engine(
             CommonConstants.ROCKET_UPWARD_BOOST_FORCE_SCALAR * Vec2d(0, -1)
         )
-        activate_left_engine_boost = lambda: ego.kinematic.external_forces.append(
+        activate_left_engine_boost = lambda: ego.activate_engine(
             CommonConstants.ROCKET_SIDEWAYS_BOOST_FORCE_SCALAR * Vec2d(-1, 0)
         )
-        activate_right_engine_boost = lambda: ego.kinematic.external_forces.append(
+        activate_right_engine_boost = lambda: ego.activate_engine(
             CommonConstants.ROCKET_SIDEWAYS_BOOST_FORCE_SCALAR * Vec2d(1, 0)
         )
 

--- a/src/scenario_overlays.py
+++ b/src/scenario_overlays.py
@@ -35,6 +35,7 @@ class ScenarioOverlays:
         debug_overlay.add_attribute(
             ego.kinematic, "external_forces", "External Forces", None
         )
+        debug_overlay.add_attribute(ego, "fuel", "Fuel", None)
         overlays.append(debug_overlay)
 
         hud_overlay = Overlay(

--- a/src/vec2d.py
+++ b/src/vec2d.py
@@ -258,6 +258,9 @@ class Vec2d(object):
     def get_length(self):
         return math.sqrt(self.x**2 + self.y**2)
 
+    def norm(self):
+        return self.get_length()
+
     def __setlength(self, value):
         length = self.get_length()
         self.x *= value / length

--- a/test/test_rocket.py
+++ b/test/test_rocket.py
@@ -72,3 +72,28 @@ class TestRocket:
         assert obj.kinematic.velocity == expected_new_velocity_meter
         with pytest.raises(ValueError):
             obj.step(non_admissible_time_step)
+
+    def test_activate_engine(self, example_image):
+        # Given
+        force_vector = Vec2d(0, -1)
+        initial_fuel = 100
+        fuel_consumption_rate = CommonConstants.FUEL_CONSUMPTION_RATE
+        expected_fuel = max(
+            0, initial_fuel - fuel_consumption_rate * force_vector.norm()
+        )
+
+        # When
+        obj = Rocket(
+            image=example_image,
+            pos=self.position,
+            mass=self.mass,
+            velocity=self.velocity,
+            external_forces=[],
+        )
+        obj.fuel = initial_fuel
+        obj.activate_engine(force_vector)
+
+        # Then
+        assert sum(obj.kinematic.external_forces) == force_vector
+        assert obj.fuel == expected_fuel
+        obj.activate_engine(force_vector)


### PR DESCRIPTION
## Changes
* add attribute `fuel` to `Rocket` object
* Create rocket method `activate_engine` that applies force and reduces fuel
* Change actions in scenario to call aforementioned method
* add ´norm´ method to vec2d
* show fuel amount in overlay

## How to test
* Manual:
  * Fuel amount shown in overlay, check reduction when activating boost
  * no boost possible once fuel amount is 0
* Unit Test:
  *  `test/test_rocket.py`